### PR TITLE
Popravio Python check_oib

### DIFF
--- a/Python/oib_validation.py
+++ b/Python/oib_validation.py
@@ -10,16 +10,16 @@ def check_oib(oib: Union[str, int]) -> bool:
     if len(oib) != OIB_LEN or not oib.isdigit():
         return False
 
-    a = 0
-    for c in oib[:-1]:
-        a += int(c)
-        a = a % 10
-        if a == 0:
-            a = 10
-        a *= 2
-        a = a % 11
+    medu_ostatak = 0
+    for digit in oib[:-1]:
+        medu_ostatak += int(digit)
+        medu_ostatak %= 10
+        if medu_ostatak == 0:
+            medu_ostatak = 10
+        medu_ostatak *= 2
+        medu_ostatak %= 11
 
-    kontrolni = OIB_LEN - a
+    kontrolni = OIB_LEN - medu_ostatak
     if kontrolni == 10:
         kontrolni = 0
 

--- a/Python/oib_validation.py
+++ b/Python/oib_validation.py
@@ -5,7 +5,7 @@ def check_oib(oib: Union[str, int]) -> bool:
     """Check if OIB is valid and return True if it is."""
     OIB_LEN = 11
     if isinstance(oib, int):
-        oib = str(oib).zfill(OIB_LEN)
+        oib = str(oib)
 
     if len(oib) != OIB_LEN or not oib.isdigit():
         return False


### PR DESCRIPTION
Funkcija check_oib za Python nije bila točna.

Primjer OIB-a koji NISU pravilni, a funkcija vraća da JESU:
2000126401, 2000126410, 2000126428

Greška je bila to što se je koristila zfill funkcija (što je potpuno bespotrebno) koja će od broja, na primjer za broj `2000126401`, napraviti `02000126401` što na  kraju izađe kao pravilan OIB **ali** mi trebamo provjeriti `2000126401`, a ne `02000126401`.

Kad sam već tu promjenio sam  imena magičnih varijabli.